### PR TITLE
Added support for multiple UIs

### DIFF
--- a/Code/ui/include/OverlayApp.hpp
+++ b/Code/ui/include/OverlayApp.hpp
@@ -25,7 +25,7 @@ namespace TiltedPhoques
 
         TP_NOCOPYMOVE(OverlayApp);
 
-        bool Initialize() noexcept;
+        bool Initialize(const std::string& acPath) noexcept;
         void Shutdown() noexcept;
 
         void ExecuteAsync(const std::string& acFunction, const CefRefPtr<CefListValue>& apArguments = nullptr) const noexcept;

--- a/Code/ui/src/OverlayApp.cpp
+++ b/Code/ui/src/OverlayApp.cpp
@@ -15,7 +15,7 @@ namespace TiltedPhoques
 
     }
 
-    bool OverlayApp::Initialize() noexcept
+    bool OverlayApp::Initialize(const std::string& acPath) noexcept
     {
         CefMainArgs args(GetModuleHandleW(nullptr));
 
@@ -56,7 +56,7 @@ namespace TiltedPhoques
         info.SetAsWindowless(m_pRenderProvider->GetWindow());
 
         const auto ret = CefBrowserHost::CreateBrowser(info, m_pClient.get(),
-            (currentPath / L"ui" / L"index.html").wstring(), browserSettings, nullptr, nullptr);
+            (currentPath / L"UI" / acPath / L"index.html").wstring(), browserSettings, nullptr, nullptr);
 
         return ret;
     }


### PR DESCRIPTION
I'm not sure if passing in a game name like `"Skyrim"` or `"Fallout"` is the best way to handle this, but this small change would allow for UI "skins" for each game. The new UI folder structure would look something like this:
![image](https://user-images.githubusercontent.com/25708893/119513641-0257e680-bd3a-11eb-94fd-5490070640f8.png)
