### PR TITLE
Fix CEF UI not showing sometimes for 1920x1080 screen sizes

### DIFF
--- a/Code/ui/include/OverlayRenderHandlerD3D11.hpp
+++ b/Code/ui/include/OverlayRenderHandlerD3D11.hpp
@@ -51,8 +51,8 @@ namespace TiltedPhoques
         void CreateRenderTexture();
 
     private:
-        uint32_t m_width{ 1920 };
-        uint32_t m_height{ 1080 };
+        uint32_t m_width{ 0 };
+        uint32_t m_height{ 0 };
 
         Microsoft::WRL::ComPtr<ID3D11Texture2D> m_pTexture;
         Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_pCursorTexture;


### PR DESCRIPTION
Since the default values were `m_width`=1920, `m_height`=1080, [this check](https://github.com/tiltedphoques/TiltedUI/blob/master/Code/ui/src/OverlayRenderHandlerD3D11.cpp#L175) was true for 1920x1080 during initialization and so [`WasResized`](https://github.com/tiltedphoques/TiltedUI/blob/master/Code/ui/src/OverlayRenderHandlerD3D11.cpp#L194-L195) wasn't being called when needed, causing `OnPaint` to never be called