### PR TITLE
Revert `windowless_frame_rate` to 60

### DIFF
--- a/Code/ui/src/OverlayApp.cpp
+++ b/Code/ui/src/OverlayApp.cpp
@@ -49,7 +49,7 @@ namespace TiltedPhoques
 
         CefBrowserSettings browserSettings{};
 
-        browserSettings.windowless_frame_rate = 240;
+        browserSettings.windowless_frame_rate = 60;
 
         CefWindowInfo info;
         info.SetAsWindowless(m_pRenderProvider->GetWindow());


### PR DESCRIPTION
From the docs: "...The minimum value is 1 and the maximum value is 60 (default 30). This value can also be changed dynamically via CefBrowserHost::SetWindowlessFrameRate."