### PR TITLE
Use D3D11 device and context provided by the game's renderer

### DIFF
--- a/Code/ui/include/OverlayRenderHandlerD3D11.hpp
+++ b/Code/ui/include/OverlayRenderHandlerD3D11.hpp
@@ -27,6 +27,8 @@ namespace TiltedPhoques
             Renderer() = default;
             virtual ~Renderer() = default;
             [[nodiscard]] virtual IDXGISwapChain* GetSwapChain() const noexcept = 0;
+            [[nodiscard]] virtual ID3D11Device* GetDevice() const noexcept = 0;
+            [[nodiscard]] virtual ID3D11DeviceContext* GetDeviceContext() const noexcept = 0;
 
             TP_NOCOPYMOVE(Renderer);
         };

--- a/Code/ui/src/OverlayRenderHandlerD3D11.cpp
+++ b/Code/ui/src/OverlayRenderHandlerD3D11.cpp
@@ -85,14 +85,10 @@ namespace TiltedPhoques
 
     void OverlayRenderHandlerD3D11::Create()
     {
-        const auto hr = m_pRenderer->GetSwapChain()->GetDevice(IID_ID3D11Device, reinterpret_cast<void**>(m_pDevice.ReleaseAndGetAddressOf()));
+        m_pDevice = m_pRenderer->GetDevice();
+        m_pImmediateContext = m_pRenderer->GetDeviceContext();
 
-        if (FAILED(hr))
-            return;
-
-        m_pDevice->GetImmediateContext(m_pImmediateContext.ReleaseAndGetAddressOf());
-
-        if (!m_pImmediateContext)
+        if (!m_pImmediateContext || !m_pDevice)
             return;
 
         GetRenderTargetSize();


### PR DESCRIPTION
Retrieving them from the swapchain is not the way